### PR TITLE
[wip] introducing `state["is_compass"]`

### DIFF
--- a/src/commands/close.py
+++ b/src/commands/close.py
@@ -4,7 +4,8 @@ from ...utils import plugin_state
 class CompassCloseCommand(sublime_plugin.WindowCommand):
     def run(self, **kwargs):
         state = plugin_state()
-        state["is_reset"] = kwargs.get("reset", False)
+        if state["is_compass"] is True:
+            state["is_reset"] = kwargs.get("reset", False)
 
         self.window.run_command("hide_overlay")
 

--- a/src/commands/show.py
+++ b/src/commands/show.py
@@ -130,6 +130,7 @@ class CompassShowCommand(sublime_plugin.WindowCommand):
         state["is_quick_panel_open"] = True
         state["highlighted_index"] = selected_index
 
+        state["is_compass"] = True
         self.window.show_quick_panel(
             items=items,
             selected_index=selected_index,
@@ -187,6 +188,7 @@ class CompassShowCommand(sublime_plugin.WindowCommand):
             state["is_quick_panel_open"] = False
             assert isinstance(sheets, File)
             self.window.open_file(sheets.get_full_path())
+            state["is_compass"] = False
             return
 
         # @todo on plugin reload, sheets are still SheetGroup because it is a subclass of List.
@@ -198,4 +200,8 @@ class CompassShowCommand(sublime_plugin.WindowCommand):
             focused = sheets.get_focused()
             if len(sheets) > 0 and focused is not None:
                 self.window.focus_sheet(focused)
+            state["is_compass"] = False
             return
+
+        state["is_compass"] = False
+

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ PLUGIN_STATE = {
     "is_quick_panel_open": False,
     "highlighted_index": 0,
     "is_reset": False,
+    "is_compass": False,
 }
 
 
@@ -16,6 +17,7 @@ def reset_plugin_state():
     state["is_quick_panel_open"] = False
     state["highlighted_index"] = 0
     state["is_reset"] = False
+    state["is_compass"] = False
 
 
 def plugin_debug(*message):


### PR DESCRIPTION
Introducing `state["is_compass"]` to distinguish whether the Compass'es quick panel is visible or not.
If it is not visible, there is no sense to handle commands or events that expected to be handled while Compass is visible.
It is a work-in-progress pull request, just to demonstrate the approach.