### PR TITLE
Refactor show.py: remove direct stack manipulation, preserve index alignment

### DIFF
--- a/src/commands/show.py
+++ b/src/commands/show.py
@@ -62,17 +62,18 @@ class CompassShowCommand(sublime_plugin.WindowCommand):
             preview = ""
             kind = None
             tags = set()
+            valid_sheets = []
 
             for sheet in sheets:
                 parsedSheet = parse_sheet(sheet)
 
                 if parsedSheet is False:
-                    stack.remove(sheet)
                     continue
 
                 names.append(parsedSheet['name'])
                 files.append(parsedSheet['file'])
                 tags = tags.union(parsedSheet['tags'])
+                valid_sheets.append(sheet)
 
                 if preview == "":
                     preview = parsedSheet['preview']
@@ -82,6 +83,10 @@ class CompassShowCommand(sublime_plugin.WindowCommand):
 
             if names.__len__() <= 0:
                 continue
+
+            # Update the sheets in the stack with only valid sheets
+            if len(valid_sheets) > 0 and len(valid_sheets) != len(sheets):
+                sheets[:] = valid_sheets
 
             trigger = ' + '.join(names)
             is_tags_enabled = settings.get('enable_tags', False)


### PR DESCRIPTION
I noticed that while the buffer (file) list in the command palette seems to always be accurate and up-to-date, occasionally navigating (selecting) one of those buffers resulted being directed to the wrong file. 

I've had this fork running locally for about a week and it seems to fix the issue, but I'm not a native python guy (web dev), so verify before accepting.

- **Remove direct stack manipulation:**  Instead of calling `stack.remove(sheet)` during iteration, now collect only valid sheets
- **Preserve index alignment:** Update the sheets list in-place only when needed, maintain correct indexing
- **Track valid sheets:** Build a `valid_sheets` list that contains only sheets that passed validation